### PR TITLE
Verify the syntactical correctness of a manifest

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -42,8 +42,9 @@
 
 (defvar puppet-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "\C-j" 'newline-and-indent)
-    (define-key map "\C-m" 'newline-and-indent)
+    (define-key map "\C-j"     'newline-and-indent)
+    (define-key map "\C-m"     'newline-and-indent)
+    (define-key map "\C-c\C-c" 'compile)
     map)
   "Key map used in puppet-mode buffers.")
 
@@ -85,6 +86,10 @@ of Emacs."
       (goto-char start)
       (while (re-search-forward re end t) (setq n (1+ n)))
       n)))
+
+(defcustom puppet-manifest-verify-command "puppet parser validate --color=no"
+  "Command to use when checking a manifest syntax"
+  :type 'string :group 'puppet)
 
 (defun puppet-comment-line-p ()
   "Return non-nil iff this line is a comment."
@@ -269,6 +274,10 @@ of the initial include plus puppet-include-indent."
           (indent-line-to cur-indent)
         (indent-line-to 0)))))
 
+(defun puppet-mode-compilation-buffer-name (&rest ignore)
+  "Return the name of puppet compilation buffer"
+  "*puppet-lint*")
+
 (defvar puppet-font-lock-syntax-table
   (let* ((tbl (copy-syntax-table puppet-mode-syntax-table)))
     (modify-syntax-entry ?_ "w" tbl)
@@ -373,6 +382,8 @@ The variable puppet-indent-level controls the amount of indentation.
        '((puppet-font-lock-keywords) nil nil))
   (set (make-local-variable 'font-lock-syntax-table)
        puppet-font-lock-syntax-table)
+  (set (make-local-variable 'compilation-buffer-name-function) 'puppet-mode-compilation-buffer-name)
+  (set (make-local-variable 'compile-command) (concat  puppet-manifest-verify-command " " (buffer-file-name)))
   (run-hooks 'puppet-mode-hook))
 
 (provide 'puppet-mode)


### PR DESCRIPTION
Change puppet-mode.el so that one can check a given manifest for syntactical
correctness with the key sequence C-c C-c. The command used to check a manifest
is "puppet parser validate", but this is configurable. The key sequence usese
the builtin "compile" command.
