### PR TITLE
melpa versoin of this mode does not associate itself to *.pp files automatically

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -375,4 +375,7 @@ The variable puppet-indent-level controls the amount of indentation.
        puppet-font-lock-syntax-table)
   (run-hooks 'puppet-mode-hook))
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.pp$" . puppet-mode))
+
 (provide 'puppet-mode)


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-syntax-emacs/issues/9

melpa version of this mode does not associate itself to *.pp files automatically.
melpa builds its files directly from this. So this mode should be updated
