### PR TITLE
Fix #1889 - Align fat arrows

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -158,6 +158,7 @@ of the initial include plus puppet-include-indent."
   "Indent current line as puppet code."
   (interactive)
   (beginning-of-line)
+  (align-current)                       ; Always align attributes
   (if (bobp)
       (indent-line-to 0)                ; First line is always non-indented
     (let ((not-indented t)


### PR DESCRIPTION
Fix [PUP-1889](https://tickets.puppetlabs.com/browse/PUP-1889).

Format resource's attributes according to the style guide, [section
9.2 "Arrow Alignment"](http://docs.puppetlabs.com/guides/style_guide#arrow-alignment).
## Current behaviour

I have a resource Exec['test']. If I indent the code (with for exemple `indent-region`), nothing happen.

``` puppet
    exec { 'test':
      subscribe => File['/etc/test'],
      refreshonly => true, | ;; cursor is here
    }
```

Hit Tab, or select resource and call `indent-region`.
Nothing change.
## New behaviour

Same resource, attributes are formatted with Tab, C-m, C-j,
`indent-region`, etc.

``` puppet
    exec { 'test':
      subscribe => File['/etc/test'],
      refreshonly => true, | ;; <- cursor is here
    }
```

Hit Tab. Attributes are formatted.

``` puppet
    exec { 'test':
      subscribe   => File['/etc/test'],
      refreshonly => true, | ;; <- cursor is here
    }
```
